### PR TITLE
fix 'make clean'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,9 +8,6 @@ kloak : src/main.c src/keycodes.c src/keycodes.h
 eventcap : src/eventcap.c
 	gcc src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
-clean :
-	rm -rf kloak eventcap src/main.o src/eventcap.o
-
 ## genmkfile - Makefile - version 1.5
 
 ## This is a copy.

--- a/make-helper-overrides.bsh
+++ b/make-helper-overrides.bsh
@@ -10,3 +10,7 @@ make_install_hook_post() {
    cp eventcap "$DESTDIR/usr/sbin/"
    cp kloak "$DESTDIR/usr/sbin/"
 }
+
+make_clean_hook_pre() {
+   rm -rf kloak eventcap src/main.o src/eventcap.o
+}


### PR DESCRIPTION
My first packaging of a package in C. Just spotted this issue. Hope this is an okay fix.

-----

fixes the following issue

make clean
/usr/share/genmkfile/makefile-full:83: warning: overriding recipe for target 'clean'

https://github.com/vmonaco/kloak/issues/3
https://github.com/vmonaco/kloak/issues/5