### PR TITLE
add service script note for hardened kernels

### DIFF
--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -43,6 +43,10 @@ ProtectHome=true
 ProtectKernelTunables=true
 ProtectKernelModules=true
 ProtectControlGroups=true
+## hardened kernels without CONFIG_USER_NS_UNPRIVILEGED=Y
+## need to:
+## * disable or comment out the 3 'Private' namespaces below
+## $ systemctl edit --full kloak
 PrivateTmp=true
 PrivateUsers=true
 PrivateNetwork=true


### PR DESCRIPTION
 * hardened kernels without `CONFIG_USER_NS_UNPRIVILEGED` fail to start the `kloak` service if private namespaces are enabled.

(I run Arch Linux's [linux-hardened with signed kernel modules](https://www.reddit.com/r/archlinux/comments/gpqbxc/linuxhardened_lts_zen_with_signed_kernel_modules/))