### PR TITLE
Fix AppArmor and seccomp

### DIFF
--- a/etc/apparmor.d/usr.sbin.kloak
+++ b/etc/apparmor.d/usr.sbin.kloak
@@ -27,8 +27,7 @@
   /etc/ld.so.cache                  r,
   /etc/ld.so.preload                r,
 
-  /{usr/,}lib{,32,64}/lib*so*       mr,
-  /{usr/,}lib/@{multiarch}/**.so*   mr,
+  /{,usr/}lib{,32,64}/**            mr,
 
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.sbin.kloak>

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Otherwise, libraries within subdirectories are denied access to and different malloc implementations such as hardened_malloc that rely on the usage of getrandom will fail. We ran into both of these issues when testing globally preloading hardened_malloc for Whonix.