### PR TITLE
Add Qubes support and include information on installing dependencies in README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all : kloak eventcap
 
 kloak : src/main.c src/keycodes.c src/keycodes.h
-	gcc -Wall -Wextra -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+	gcc -Wall -Wextra -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O3 -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security -mindirect-branch=thunk -mfunction-return=thunk  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 eventcap : src/eventcap.c
 	gcc src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all : kloak eventcap
 
 kloak : src/main.c src/keycodes.c src/keycodes.h
-	gcc src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+	gcc -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 eventcap : src/eventcap.c
 	gcc src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all : kloak eventcap
 
 kloak : src/main.c src/keycodes.c src/keycodes.h
-	gcc -Wall -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+	gcc -Wall -Wextra -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 eventcap : src/eventcap.c
 	gcc src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all : kloak eventcap
 
 kloak : src/main.c src/keycodes.c src/keycodes.h
-	gcc -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
+	gcc -Wall -Wstack-protector -fstack-protector-strong -fstack-clash-protection -pie -fPIE -D_FORTIFY_SOURCE=2 -O -Wl,-z,relro,-z,now -Wl,-z,noexecstack -Wformat -Wformat-security  src/main.c src/keycodes.c -o kloak -lm $(shell pkg-config --cflags --libs libevdev) $(shell pkg-config --cflags --libs libsodium) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)
 
 eventcap : src/eventcap.c
 	gcc src/eventcap.c -o eventcap $(CPPFLAGS) $(CFLAGS) $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Debian:
 
     $ sudo apt install make pkg-config libsodium23 libsodium-dev libevdev2 libevdev-dev
 
-<h4>Build and run `kloak`</h4>
+<h4>Build and run kloak</h4>
 
 Compile `kloak` and the event capture tool `eventcap`:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are two ways to run kloak:
 
 ### As an application
 
-####Install dependencies:
+<h4>Install dependencies:</h4>
 
 Fedora:
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Start `kloak` by specifying the input and output device files:
 
 `kloak` works by introducing a random delay to each key press and release event. This requires temporarily buffering the event before it reaches the application (e.g., a text editor).
 
-The maximum delay is specified with the -d option. This is the maximum delay (in milliseconds) that can occur between the physical key events and writing key events to the user-level input device. The default is 100 ms, which was shown to achieve about a 20-30% reduction in identification accuracy and doesn't create too much lag between the user and the application (see the paper below). As the maximum delay increases, the ability to obfuscate typing behavior also increases and the responsive of the application decreases. This reflects a tradeoff between usability and privacy.
+The maximum delay is specified with the -d option. This is the maximum delay (in milliseconds) that can occur between the physical key events and writing key events to the user-level input device. The default is 100 ms, which was shown to achieve about a 20-30% reduction in identification accuracy and doesn't create too much lag between the user and the application (see the paper below). As the maximum delay increases, the ability to obfuscate typing behavior also increases and the responsiveness of the application decreases. This reflects a tradeoff between usability and privacy.
 
 If you're a fast typist and it seems like there is a long lag between pressing a key and seeing the character on screen, try lowering the maximum delay. Alternately, if you're a slower typist, you might be able to increase the maximum delay without noticing much difference. Automatically determining the best lag for each typing speed is an item for future work.
 
@@ -155,12 +155,12 @@ The full usage and options are:
 
 ## Try it out
 
-You can test that `kloak` actually works by trying an [online keystroke biometrics demo](https://www.keytrac.net/en/tryout). For example, try these three different scenarios:
+Consider these three different scenarios:
 * Train normal, test normal
 * Train normal, test kloak
 * Train `kloak`, test `kloak`
 
-*Train normal* means to train with normal typing behavior, i.e., without `kloak` running. At the enrollment page on the KeyTrac demo, enter a username and password without `kloak` running, and then on the authenticate page, try authenticating. For example, the train normal/test normal result is:
+*Train normal* means to train with normal typing behavior, i.e., without `kloak` running. At the enrollment page on the KeyTrac demo (demo no longer available), enter a username and password without `kloak` running, and then on the authenticate page, try authenticating. For example, the train normal/test normal result is:
 
 <div align="center">
   <img src="figures/train-normal_test-normal.png"><br><br>
@@ -172,7 +172,7 @@ Start `kloak` and then try authenticating again. These results were obtained usi
   <img src="figures/train-normal_test-kloak.png"><br><br>
 </div>
 
-Now go back to the [enrollment page](https://www.keytrac.net/en/tryout). Enroll With `kloak` running and then try authenticating with `kloak` still running. Again, this is with a 200 ms maximum delay. The train `kloak`/test `kloak` result is:
+Enroll With `kloak` running and then try authenticating with `kloak` still running. Again, this is with a 200 ms maximum delay. The train `kloak`/test `kloak` result is:
 
 <div align="center">
   <img src="figures/train-kloak_test-kloak.png"><br><br>
@@ -204,5 +204,5 @@ The time between key press and release events are typically used to identify use
 
 * If the delay is too small, it is not effective. Adjust the delay to as high a value that's comfortable.
 * Repeated key presses are not obfuscated. If your system is set to repeat held-down keys at a unique rate, this could leak your identity.
-* Writing style is still apparent, in which [stylometry techniques could be used to determine authorship](http://www.vmonaco.com/publications/An%20investigation%20of%20keystroke%20and%20stylometry%20traits%20for%20authenticating%20online%20test%20takers.pdf).
+* Writing style is still apparent, in which [stylometry techniques could be used to determine authorship](https://vmonaco.com/papers/An%20investigation%20of%20keystroke%20and%20stylometry%20traits%20for%20authenticating%20online%20test%20takers.pdf).
 * Higher level cognitive behavior, such as editing and application usage, are still apparent. These lower-frequency actions are less understood at this point, but could potentially be used to reveal identity.

--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ There are two ways to run kloak:
 ### As an application
 
 Install dependencies:
+
 Fedora:
-  $ sudo dnf install make pkgconf-pkg-config libsodium libsodium-devel libevdev libevdev-devel
+
+    $ sudo dnf install make pkgconf-pkg-config libsodium libsodium-devel libevdev libevdev-devel
 
 Debian:
-  $ sudo apt install make pkg-config libsodium23 libsodium-dev libevdev2 libevdev-dev
+
+    $ sudo apt install make pkg-config libsodium23 libsodium-dev libevdev2 libevdev-dev
 
 Compile `kloak` and the event capture tool `eventcap`:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ There are two ways to run kloak:
 
 ### As an application
 
-Install dependencies:
+####Install dependencies:
 
 Fedora:
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,14 @@ There are two ways to run kloak:
 
 ### As an application
 
-First, compile `kloak` and the event capture tool `eventcap`:
+Install dependencies:
+Fedora:
+  $ sudo dnf install make pkgconf-pkg-config libsodium libsodium-devel libevdev libevdev-devel
+
+Debian:
+  $ sudo apt install make pkg-config libsodium23 libsodium-dev libevdev2 libevdev-dev
+
+Compile `kloak` and the event capture tool `eventcap`:
 
     $ make all
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Debian:
 
     $ sudo apt install make pkg-config libsodium23 libsodium-dev libevdev2 libevdev-dev
 
+<h4>Build and run `kloak`</h4>
+
 Compile `kloak` and the event capture tool `eventcap`:
 
     $ make all

--- a/auto-generated-man-pages/kloak.8
+++ b/auto-generated-man-pages/kloak.8
@@ -31,6 +31,10 @@ startup_timeout: time to wait (milliseconds) before startup\. Default 100\.
 .IP
 csv_string: csv list of rescue key names to exit kloak in case the keyboard becomes unresponsive\. Default is 'KEY_LEFTSHIFT,KEY_RIGHTSHIFT,KEY_ESC'\.
 .IP "\[ci]" 4
+\-n
+.IP "\[ci]" 4
+max_mouse_noise: max number of pixels the mouse will move perpendicular when adding noise to mouse movements\. Default is 0 (disabled)\.
+.IP "\[ci]" 4
 \-v
 .IP
 verbose mode

--- a/auto-generated-man-pages/kloak.8
+++ b/auto-generated-man-pages/kloak.8
@@ -32,7 +32,7 @@ startup_timeout: time to wait (milliseconds) before startup\. Default 100\.
 csv_string: csv list of rescue key names to exit kloak in case the keyboard becomes unresponsive\. Default is 'KEY_LEFTSHIFT,KEY_RIGHTSHIFT,KEY_ESC'\.
 .IP "\[ci]" 4
 \-n
-.IP "\[ci]" 4
+.IP
 max_mouse_noise: max number of pixels the mouse will move perpendicular when adding noise to mouse movements\. Default is 0 (disabled)\.
 .IP "\[ci]" 4
 \-v

--- a/auto-generated-man-pages/kloak.8
+++ b/auto-generated-man-pages/kloak.8
@@ -21,7 +21,11 @@ filename: device file to write events to (should be uinput)
 .IP "\[ci]" 4
 \-d
 .IP
-delay: maximum delay (milliseconds) of released events\. Default 100\.
+delay: maximum delay (milliseconds) of key events\. Default 100\.
+.IP "\[ci]" 4
+\-m
+.IP
+delay: maximum delay (milliseconds) of mouse movement events\. Default 20\.
 .IP "\[ci]" 4
 \-s
 .IP

--- a/auto-generated-man-pages/kloak.8
+++ b/auto-generated-man-pages/kloak.8
@@ -35,6 +35,10 @@ startup_timeout: time to wait (milliseconds) before startup\. Default 100\.
 .IP
 csv_string: csv list of rescue key names to exit kloak in case the keyboard becomes unresponsive\. Default is 'KEY_LEFTSHIFT,KEY_RIGHTSHIFT,KEY_ESC'\.
 .IP "\[ci]" 4
+\-t
+.IP
+disable_csv_string: csv list of key names to temporarily disable and re-enable adding delay and noise\. Default is 'KEY_LEFTCTRL,KEY_RIGHTCTRL'\.
+.IP "\[ci]" 4
 \-n
 .IP
 max_mouse_noise: max number of pixels the mouse will move perpendicular when adding noise to mouse movements\. Default is 0 (disabled)\.

--- a/etc/apparmor.d/usr.sbin.kloak
+++ b/etc/apparmor.d/usr.sbin.kloak
@@ -33,6 +33,8 @@
   /var/run/qubes r,
   /var/run/qubes/ r,
 
+  /etc/kloak/kloak.conf r,
+
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.sbin.kloak>
 }

--- a/etc/apparmor.d/usr.sbin.kloak
+++ b/etc/apparmor.d/usr.sbin.kloak
@@ -30,6 +30,9 @@
 
   /{,usr/}lib{,32,64}/**            mr,
 
+  /var/run/qubes r,
+  /var/run/qubes/ r,
+
   # Site-specific additions and overrides. See local/README for details.
   #include <local/usr.sbin.kloak>
 }

--- a/etc/kloak/kloak.conf
+++ b/etc/kloak/kloak.conf
@@ -1,0 +1,40 @@
+# options added in command line options override values in the config file
+## order of precedence from highest to lowest: command line option -> config file -> default in kloak
+# spaces are ignored, lines starting with # are comments
+
+
+
+# max delay in ms added to key events
+MAX_DELAY_MS = 20
+
+
+# max delay in ms added to mouse movements
+MAX_MOUSE_DELAY_MS = 20
+
+
+# max number of pixels when adding noise to mouse cursor movements (0 is disabled)
+MAX_NOISE = 0
+
+
+# rescue key names used to exit kloak (MAX 3 keys)
+KEYS = KEY_LEFTSHIFT,KEY_RIGHTSHIFT,KEY_ESC
+
+
+# key names used to temporarily disable or re-enable kloak (MAX 3 keys)
+DISABLE_KEYS = KEY_LEFTCTRL,KEY_RIGHTCTRL
+
+
+# number of ms to wait before grabbing the input devices
+STARTUP_DELAY_MS = 500
+
+
+# verbose output (0 is disabled, 1 is enabled)
+VERBOSE = 0
+
+
+# max number of devices
+MAX_DEVICES = 32
+
+# timeout to check for new events
+POLL_TIMEOUT_MS = 1
+

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat newfstatat clock_nanosleep pselect6 shmctl poll openat inotify_add_watch inotify_init1 clone3 wait4
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom newfstatat clock_nanosleep pselect6 poll shmctl openat inotify_add_watch inotify_init1 clone3 wait4
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat fstatat newfstatat clock_nanosleep pselect6 shmctl poll openat
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat fstatat newfstatat clock_nanosleep pselect6 shmctl poll openat inotify_add_watch inotify_init1
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat fstatat newfstatat
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat fstatat newfstatat
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat fstatat newfstatat clock_nanosleep pselect6 shmctl poll openat
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom newfstatat clock_nanosleep pselect6 poll shmctl openat inotify_add_watch inotify_init1 clone3 wait4
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom newfstatat clock_nanosleep pselect6 poll
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat fstatat newfstatat clock_nanosleep pselect6 shmctl poll openat inotify_add_watch inotify_init1
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom stat newfstatat clock_nanosleep pselect6 shmctl poll openat inotify_add_watch inotify_init1 clone3 wait4
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/systemd/system/kloak.service
+++ b/lib/systemd/system/kloak.service
@@ -55,7 +55,7 @@ NoNewPrivileges=true
 RestrictRealtime=true
 RestrictNamespaces=true
 SystemCallArchitectures=native
-SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom newfstatat clock_nanosleep pselect6 poll
+SystemCallFilter=ioctl nanosleep select write read openat close brk fstat lseek mmap mprotect munmap rt_sigaction rt_sigprocmask access execve getuid arch_prctl set_tid_address set_robust_list prlimit64 pread64 getrandom newfstatat clock_nanosleep pselect6 poll shmctl openat inotify_add_watch inotify_init1 clone3 wait4
 
 [Install]
 WantedBy=multi-user.target

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -10,7 +10,7 @@ int supports_event_type(int , int );
 int supports_specific_key(int, unsigned int);
 int is_keyboard(int );
 int is_mouse(int );
-void get_device_number(char *, char *);
+void get_device_number(char* dev_num, char* device_path, const int max_len);
 int change_qubes_input_sender(char *, char *);
 void restart_all_qubes_input_sender();
 void detect_devices();
@@ -18,7 +18,8 @@ void cleanup_device(char * );
 void init_new_input(char * );
 void init_inputs();
 void init_outputs();
-
+int only_digits(const char*, const int);
+void cleanup();
 
 void main_loop();
 void usage();

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -1,0 +1,12 @@
+#ifndef KLOAK_H_
+#define KLOAK_H_
+
+
+void banner();
+void init_new_input(char *);
+void cleanup_device(char *);
+void print_device_name(char *);
+
+
+
+#endif

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -10,7 +10,7 @@ int supports_event_type(int , int );
 int supports_specific_key(int, unsigned int);
 int is_keyboard(int );
 int is_mouse(int );
-void get_device_number(char* dev_num, char* device_path, const int max_len);
+void get_device_number(char* dev_num, char* device_path);
 int change_qubes_input_sender(char *, char *);
 void restart_all_qubes_input_sender();
 void detect_devices();

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -6,6 +6,7 @@ void sleep_ms(long );
 long current_time_ms(void);
 long int random_between(long int, long int);
 void set_rescue_keys(char* );
+void set_disable_keys(char* );
 int supports_event_type(int , int );
 int supports_specific_key(int, unsigned int);
 int is_keyboard(int );

--- a/src/kloak.h
+++ b/src/kloak.h
@@ -2,6 +2,27 @@
 #define KLOAK_H_
 
 
+void sleep_ms(long );
+long current_time_ms(void);
+long int random_between(long int, long int);
+void set_rescue_keys(char* );
+int supports_event_type(int , int );
+int supports_specific_key(int, unsigned int);
+int is_keyboard(int );
+int is_mouse(int );
+void get_device_number(char *, char *);
+int change_qubes_input_sender(char *, char *);
+void restart_all_qubes_input_sender();
+void detect_devices();
+void cleanup_device(char * );
+void init_new_input(char * );
+void init_inputs();
+void init_outputs();
+
+
+void main_loop();
+void usage();
+
 void banner();
 void init_new_input(char *);
 void cleanup_device(char *);

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,7 @@
 #define POLL_TIMEOUT_MS 1 // timeout to check for new events
 #define DEFAULT_MAX_DELAY_MS 20  // upper bound on event delay
 #define DEFAULT_MAX_MOUSE_DELAY_MS 20  // upper bound on mouse event delay
-#define DEFAULT_MAX_NOISE 0
+#define DEFAULT_MAX_NOISE 0     // max number of pixels of adversarial noise added to mouse movements
 #define DEFAULT_STARTUP_DELAY_MS 500  // wait before grabbing the input device
 
 
@@ -1256,7 +1256,7 @@ int main(int argc, char **argv) {
                                                 continue;
                                         }
                                         sscanf(value, "%d", &max_delay);
-                                        printf("Set %s to %s\n", option, value);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
 
                                 } else if (opt_length == 9 && strncmp(option, "MAX_NOISE", 9) == 0) {
 
@@ -1266,12 +1266,15 @@ int main(int argc, char **argv) {
                                                 continue;
                                         }
                                         sscanf(value, "%d", &max_noise);
-                                        printf("Set %s to %s\n", option, value);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
+
 
 
                                 } else if (opt_length == 4 && strncmp(option, "KEYS", 4) == 0) {
                                         sscanf(value, "%s", rescue_keys_str);
-                                        printf("Set %s to %s\n", option, value);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
+
+                                        
                                 } else if (opt_length == 16 && strncmp(option, "STARTUP_DELAY_MS", 16) == 0) {
 
                                         if(!only_digits(value, val_length)) {
@@ -1280,13 +1283,15 @@ int main(int argc, char **argv) {
                                                 continue;
                                         }
                                         sscanf(value, "%d", &startup_timeout);
-                                        printf("Set %s to %s\n", option, value);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
 
 
                                 } else if(opt_length == 7 && strncmp(option, "VERBOSE", 7) == 0) {
                                         if(val_length == 1 && (value[0] == '0' || value[0] == 1)) {
                                                 sscanf(value, "%d", &verbose);
-                                                printf("Set %s to %s\n", option, value);
+                                                printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
+
+                                                
                                         } else {
                                                 printf( YELLOW("Invalid value ")  "%s " YELLOW("for option ") "%s\n", value, option);
 
@@ -1299,16 +1304,20 @@ int main(int argc, char **argv) {
                                                 continue;
                                         }
                                         sscanf(value, "%d", &max_devices);
-                                        printf("Set %s to %s\n", option, value);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
+
+                                        
                                 } else if(opt_length == 15 && strncmp(option, "POLL_TIMEOUT_MS", 15) == 0) {
                                         if(!only_digits(value, val_length)) {
                                                 printf( YELLOW("Invalid value ")  "%s " YELLOW("for option ") "%s\n", value, option);
                                                 continue;
                                         }
                                         sscanf(value, "%d", &poll_timeout_ms);
-                                        printf("Set %s to %s\n", option, value);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
+
+                                        
                                 } else {
-                                        printf( YELLOW("Unknown option in config file:") " %s\n", option);
+                                        printf( "Unknown option in config file:" YELLOW(" %s\n"), option);
                                 }
                         }
 

--- a/src/main.c
+++ b/src/main.c
@@ -10,12 +10,15 @@
 #include <libevdev/libevdev.h>
 #include <libevdev/libevdev-uinput.h>
 #include <ctype.h>
+#include <sys/inotify.h>
+#include <fcntl.h>
 
+#include "kloak.h"
 #include "keycodes.h"
 
 #define BUFSIZE 256  // for device names and rescue key sequence
-#define MAX_INPUTS 16  // number of devices to try autodetection
-#define MAX_DEVICES 16 // max number of devices to read events from
+#define MAX_INPUTS 32  // number of devices to try autodetection
+#define MAX_DEVICES 32 // max number of devices to read events from
 #define MAX_RESCUE_KEYS 10  // max number of rescue keys to exit in case of emergency
 #define MIN_KEYBOARD_KEYS 20  // need at least this many keys to be a keyboard
 #define POLL_TIMEOUT_MS 1 // timeout to check for new events
@@ -36,6 +39,9 @@
 #define mouse_move_with_obfuscation ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)
 #define abs(x) ((x >= 0) ? x : x * -1)
 
+#define INOTIFY_EVENT_SIZE sizeof(struct inotify_event)
+#define INOTIFY_EVENT_BUFFER_SIZE (128 * (INOTIFY_EVENT_SIZE + 16))
+
 static int interrupt = 0;  // flag to interrupt the main loop and exit
 static int verbose = 0;  // flag for verbose output
 
@@ -54,6 +60,8 @@ static char named_inputs[MAX_INPUTS][BUFSIZE];
 static int input_fds[MAX_INPUTS];
 struct libevdev *output_devs[MAX_INPUTS];
 struct libevdev_uinput *uidevs[MAX_INPUTS];
+
+struct pollfd *pfds;
 
 static int is_qubes = 0;
 
@@ -171,7 +179,7 @@ int is_mouse(int fd) {
 // extracts device number from device_path and puts it into dev_num
 void get_device_number(char *dev_num, char *device_path) {
 
-        snprintf(dev_num, 3, device_path + 16);
+        snprintf(dev_num, 5, device_path + 16);
 
 }
 
@@ -184,7 +192,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
         const int MAX_COMMAND_LEN = 155;
         char command[MAX_COMMAND_LEN];
 
-        char dev_num[3];
+        char dev_num[5];
 
         get_device_number(dev_num, device_path);
 
@@ -195,8 +203,8 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
         if(strncmp(systemd_command, "stop", 4) == 0 || strncmp(systemd_command, "start", 5) == 0) {
                 status = change_qubes_input_sender("status", device_path);
 
-                if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || strncmp(systemd_command, "start", 5) == 0) {
-                        snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
+                if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || (strncmp(systemd_command, "start", 5) == 0)) {
+                        snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard@event%s.service 2> /dev/null > /dev/null &", systemd_command , dev_num);
 
                         if(verbose) {
                                 printf("Executing: %s\n", command);
@@ -213,7 +221,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                         status = system(command);
                         
                         if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || (status == 3 && strncmp(systemd_command, "start", 5) == 0)) {
-                                snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard-mouse@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
+                                snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard-mouse@event%s.service 2> /dev/null > /dev/null &", systemd_command , dev_num);
                                 if(verbose) {
                                         printf("Executing: %s\n", command);
                                 }
@@ -291,6 +299,346 @@ void detect_devices() {
 
 
 
+
+
+void cleanup() {
+
+        if(verbose) {
+                printf("Final clean up\n");
+        }
+        // close everything
+        for (int i = 0; i < device_count; i++) {
+                libevdev_uinput_destroy(uidevs[i]);
+                libevdev_free(output_devs[i]);
+                close(input_fds[i]);
+
+
+
+                // if in qubes, restart the associated qubes-input-sender service for each of the input devices
+                if(is_qubes) {
+                        change_qubes_input_sender("start", named_inputs[i]);
+                }
+        }
+
+
+
+
+        device_count = 0;
+}
+
+void cleanup_device(char * event_file) {
+        int fd;
+        int one = 1;
+
+
+        char device[256];
+        sprintf(device, "/dev/input/%s", event_file);
+
+        if(verbose) {
+                printf("Cleaning up: %s\n", device);
+        }
+
+        // not an event file
+        if(strncmp(event_file, "event", 5) != 0) {
+                // if(verbose) {
+                        // printf("%s is not an event file, skipping clenaup\n", device);
+                // }
+                return;
+        }
+
+        
+
+
+
+
+        int device_number = -1;
+
+        int device_len = strlen(device);
+
+        int named_len = 0;
+
+        // find the device's index
+        for(int i = 0; i < device_count; i++) {
+                
+                named_len = strlen(named_inputs[i]);
+                if(device_len == named_len && strcmp(device, named_inputs[i]) == 0) {
+
+                        device_number = i;
+
+                        if(verbose) {
+                                printf("matched: %s\n", named_inputs[device_number]);
+                        }
+
+                        break;
+
+                }
+        }
+
+        // not in named_inputs, don't need to clean
+        if(device_number == -1) {
+                return;
+        }
+
+
+
+        // if(verbose) {
+                // printf("Running cleanup operations for : %s\n", named_inputs[device_number]);
+        // }
+
+        // these aren't needed after the device has been removed and will cause the cleanup to error out with a double free
+        // libevdev_uinput_destroy(uidevs[device_number]);
+        // libevdev_free(output_devs[device_number]);
+        close(input_fds[device_number]);
+
+        // if(verbose) {
+                // printf("Closed input_fd for %s\n", device);
+        // }
+
+
+        // TODO: detaching and re-attaching mouse works perfectly, detaching keyboard breaks mouse for some reason. Re-attaching keyboard after fixes both, very strange
+        // likely something here in cleanup causing it
+
+        // shift everything after to the left 1
+        for(int i = device_number; i < device_count-1; i++) {
+                strcpy(named_inputs[i], named_inputs[i+1]);
+                input_fds[i] = input_fds[i+1];
+                output_devs[i] = output_devs[i+1];
+                uidevs[i] = uidevs[i+1];
+        }
+
+        device_count -= 1;
+
+        if(verbose) {
+                printf("Done cleaning up: %s, new device count: %d\n", device, device_count);
+        }
+
+        // re-load input file descriptors for polling
+        pfds = calloc(device_count, sizeof(struct pollfd));
+        for (int j = 0; j < device_count; j++) {
+                pfds[j].fd = input_fds[j];
+                pfds[j].events = POLLIN;
+        }
+
+        if(verbose) {
+                printf("Reloaded input file descriptors\n\n");
+        }
+
+
+}
+
+void init_new_input(char * event_file) {
+
+        if(device_count == MAX_DEVICES) {
+                return;
+        }
+
+        int fd;
+        int one = 1;
+
+        // not an event file
+        if(strncmp(event_file, "event", 5) != 0) {
+                return;
+        }
+
+        char device[256];
+        sprintf(device, "/dev/input/%s", event_file);
+
+
+
+        if(verbose) {
+                printf("Initializing: %s: ", device);
+                print_device_name(device);
+                printf("\n");
+        }
+
+
+
+        // if in qubes, need to stop associated qubes-input-sender service before ioctls work on the device file
+        if(is_qubes) {
+                // stop the service
+                change_qubes_input_sender("stop", device);
+        }
+
+        if ((fd = open(device, O_RDONLY)) >= 0) {
+
+                char dev_path[256];
+                ioctl(fd, EVIOCGPHYS(256), dev_path);
+
+                for(int i = 0; i < device_count; i++) {
+
+                        // make sure there isn't garbage in dev_path, skip initialization if there is
+                        if(isalpha(dev_path[0]) == 0) {
+                                if(verbose) {
+                                        printf("Garbage in dev_path\n");
+                                }
+                                change_qubes_input_sender("start", device);
+                                return;
+                        }
+
+                        int current_path = libevdev_get_phys(output_devs[i]);
+
+                        if(strlen(dev_path) == strlen(current_path)) {
+                                printf("Comparing %s and %s \n", dev_path, current_path);
+                        } else {
+                                // printf("Lengths don't match\n");
+                                continue;
+                        }
+
+                        // device is already handled by kloak, skip initialization
+                        if(strlen(dev_path) == strlen(current_path) && strncmp(dev_path, current_path, strlen(dev_path)) == 0) {
+                                if(verbose) {
+                                        printf("Device is already handled\n");
+                                }
+                                change_qubes_input_sender("start", device);
+                                return;
+                        }
+                }
+
+                if(verbose) {
+                        printf("Loop ended for %s\n", device);
+                }
+
+                // struct input_id iid;
+                // ioctl(fd, sizeof(struct input_id), iid);
+
+                // printf("\n\nProduct ID from input_id: %d\n\n", iid.product);
+
+                // char uniq[2048];
+
+                // ioctl(fd, EVIOCGUNIQ(sizeof(uniq)), uniq);
+
+                // printf("\n\nUnique identifier at beginning of init_new_device: %s\n\n", uniq);
+
+                
+                if (is_keyboard(fd) || is_mouse(fd)) {
+                        // printf("Device Count: %d\n", device_count);
+                        strncpy(named_inputs[device_count], device, BUFSIZE-1);
+                        if (verbose) {
+                                printf("Found new device: ");
+                                print_device_name(device);
+                                printf("\n");
+                        }
+
+                        // set the device to nonblocking mode
+                        if (ioctl(fd, FIONBIO, &one) < 0) {
+
+                                // if in qubes, make sure qubes-input-sender service is running before panic
+                                if(is_qubes) {
+                                        restart_all_qubes_input_sender();
+                                }
+
+                                panic("Could not set to nonblocking: %s", named_inputs[device_count]);
+                        }
+
+                        if(verbose) {
+                                printf("Put %s into nonblocking mode\n", device);
+                        }
+
+                        // grab the input device
+                        if (ioctl(fd, EVIOCGRAB, &one) < 0) {
+
+                                // if in qubes, make sure qubes-input-sender service is running before panic
+                                if(is_qubes) {
+                                        restart_all_qubes_input_sender();
+                                }
+
+                                panic("Could not grab: %s", named_inputs[device_count]);
+                        }
+
+                        if(verbose) {
+                                printf("Grabbed %s\n", device);
+                        }
+
+
+                        input_fds[device_count] = fd;
+
+                        if(verbose) {
+                                printf("Put %s into input_fds\n", device);
+                        }
+                        
+
+
+                        int err = libevdev_new_from_fd(input_fds[device_count], &output_devs[device_count]);
+                        
+                        if (err != 0){
+                                // if in qubes, make sure qubes-input-sender service is running before panic
+                                if(is_qubes) {
+                                        restart_all_qubes_input_sender();
+                                }
+
+                                panic("Could not create evdev for input device: %s", named_inputs[device_count]);
+                        }
+
+                        if(verbose) {
+                                printf("Finished new_from_fd for %s\n", device);
+                        }
+
+                        // not an actual vendor id, used to avoid running this again on the device created by libevdev
+                        // libevdev_set_id_vendor(output_devs[device_count], 1);
+                        // libevdev_set_id_product(output_devs[device_count], 1);
+
+                        // char new_location[256];
+
+                        // snprintf(new_location, 256, "/dev/input/libevdev%d", device_count);
+
+                        // libevdev_set_phys(output_devs[device_count], new_location);
+
+                        // printf("\n\nPhysical Location: %s\n\n", libevdev_get_phys(output_devs[device_count]));
+
+
+
+                        // printf("\n\nUnique identifier for newly created device: %d\n\n", libevdev_get_id_version(output_devs[device_count]));
+
+
+                        err = libevdev_uinput_create_from_device(output_devs[device_count], LIBEVDEV_UINPUT_OPEN_MANAGED, &uidevs[device_count]);
+
+                        if(verbose) {
+                                printf("Finished create_from_device for %s\n", device);
+                        }
+
+                        if (err != 0) {
+                                // if in qubes, make sure qubes-input-sender service is running before panic
+                                if(is_qubes) {
+                                        restart_all_qubes_input_sender();
+                                }
+
+                                panic("Could not create uidev for input device: %s", named_inputs[device_count]);
+                        }
+
+                        device_count += 1;
+
+
+                        if(verbose) {
+                                printf("Reloading input file descriptors for polling\n");
+                        }
+                        // re-load input file descriptors for polling
+                        pfds = calloc(device_count, sizeof(struct pollfd));
+                        for (int j = 0; j < device_count; j++) {
+                                pfds[j].fd = input_fds[j];
+                                pfds[j].events = POLLIN;
+                        }
+
+
+                } else if (is_qubes && (change_qubes_input_sender("status", device) == 3)) { 
+
+                        close(fd);
+                        
+                        // if not keyboard and mouse, in case qubes-input-sender was stopped, restart it. Don't restart if keyboard or mouse
+                        change_qubes_input_sender("start", device);
+                        
+                }
+
+        }
+
+
+        if(verbose) {
+                printf("Done initializing: ");
+                print_device_name(device);
+                printf("\n");
+        }
+
+}
+
 void init_inputs() {
         int fd;
         int one = 1;
@@ -304,12 +652,6 @@ void init_inputs() {
 
                         // stop the service
                         change_qubes_input_sender("stop", named_inputs[i]);
-
-                        // check status to make sure the service it was definitely stopped
-                        if(change_qubes_input_sender("status", named_inputs[i]) == 0) {
-                                panic("Failed to stop qubes-input-sender service for %s", named_inputs[i]);
-                        }
-
                 }
 
 
@@ -388,11 +730,11 @@ void emit_event(struct entry *e) {
 
         libevdev_uinput_write_event(uidevs[e->device_index], e->iev.type, e->iev.code, e->iev.value);
 
-        if (verbose) {
-                printf("Released event at time : %ld. Device: %d,  Type: %*d,  "
-                       "Code: %*d,  Value: %*d,  Missed target:  %*d ms \n",
-                       e->time, e->device_index, 3, e->iev.type, 5, e->iev.code, 5, e->iev.value, 5, delay);
-        }
+        // if (verbose) {
+        //         printf("Released event at time : %ld. Device: %d,  Type: %*d,  "
+        //                "Code: %*d,  Value: %*d,  Missed target:  %*d ms \n",
+        //                e->time, e->device_index, 3, e->iev.type, 5, e->iev.code, 5, e->iev.value, 5, delay);
+        // }
 }
 
 void main_loop() {
@@ -417,11 +759,29 @@ void main_loop() {
         }
 
         // load input file descriptors for polling
-        struct pollfd *pfds = calloc(device_count, sizeof(struct pollfd));
+        pfds = calloc(device_count, sizeof(struct pollfd));
         for (int j = 0; j < device_count; j++) {
                 pfds[j].fd = input_fds[j];
                 pfds[j].events = POLLIN;
         }
+
+        // inotify file descriptor
+        int ino_fd = inotify_init1(IN_NONBLOCK);
+
+        if(ino_fd < 0) {
+                panic("Failed to create inotify file descriptor\n");
+        }
+
+
+        // watch /dev/input for filesystem events, except IN_ACCESS (noisy)
+        int watch_fd = inotify_add_watch(ino_fd, "/dev/input/", IN_ALL_EVENTS);
+
+        if(watch_fd < 0) {
+                panic("Failed to create watch file descriptor\n");
+        }
+
+
+        
 
         // the main loop breaks when the rescue keys are detected
         // On each iteration, wait for input from the input devices
@@ -431,6 +791,41 @@ void main_loop() {
         // so that events are always scheduled in the order they
         // arrive (FIFO).
         while (!interrupt) {
+
+                char event_buffer[BUFSIZE];
+                int len = 0;
+                len = read(ino_fd, event_buffer, BUFSIZE);
+
+                if(len > 0) {
+                        int i = 0;
+                        while(i < len) {
+                                struct inotify_event *ino_event = (struct inotify_event *) &event_buffer[i];
+                                char path[30];
+                                char dev_name[256];
+
+                                snprintf(path, 30, "/dev/input/%s", ino_event->name);
+
+                                // if((ino_event->mask & IN_CREATE) != 0 || (ino_event->mask & IN_DELETE) != 0 || (ino_event->mask & IN_DELETE_SELF) != 0) {
+                                //         printf("Mask: %d, name: %s\n", ino_event->mask, ino_event->name);
+                                // }
+
+
+                                if((ino_event->mask & IN_CREATE) != 0) {
+                                        init_new_input(ino_event->name);
+                                } else if(((ino_event->mask & IN_DELETE) != 0) || ((ino_event->mask & IN_DELETE_SELF) != 0)) {
+                                        cleanup_device(ino_event->name);
+                                }
+
+
+                                i += INOTIFY_EVENT_SIZE + ino_event->len;
+
+                        }
+
+                        
+
+                }
+
+
                 // Emit any events exceeding the current time
                 current_time = current_time_ms();
                 while ((np = TAILQ_FIRST(&head)) && (current_time >= np->time)) {
@@ -438,6 +833,7 @@ void main_loop() {
                         TAILQ_REMOVE(&head, np, entries);
                         free(np);
                 }
+
 
                 // Wait for next input event
                 if ((err = poll(pfds, device_count, POLL_TIMEOUT_MS)) < 0) {
@@ -448,6 +844,7 @@ void main_loop() {
 
                         panic("poll() failed: %s\n", strerror(errno));
                 }
+
 
                 // timed out, do nothing
                 if (err == 0)
@@ -641,15 +1038,15 @@ void main_loop() {
                                         prev_release_time = n5->time;
                                 }
 
-                                if (verbose) {
-                                        printf("Bufferred event at time: %ld. Device: %d,  Type: %*d,  "
-                                               "Code: %*d,  Value: %*d,  Scheduled delay: %*ld ms \n",
-                                               n1->time, k, 3, n1->iev.type, 5, n1->iev.code, 5, n1->iev.value,
-                                               4, random_delay);
-                                        if (lower_bound > 0) {
-                                                printf("Lower bound raised to: %*ld ms\n", 4, lower_bound);
-                                        }
-                                }
+                                // if (verbose) {
+                                //         printf("Bufferred event at time: %ld. Device: %d,  Type: %*d,  "
+                                //                "Code: %*d,  Value: %*d,  Scheduled delay: %*ld ms \n",
+                                //                n1->time, k, 3, n1->iev.type, 5, n1->iev.code, 5, n1->iev.value,
+                                //                4, random_delay);
+                                //         if (lower_bound > 0) {
+                                //                 printf("Lower bound raised to: %*ld ms\n", 4, lower_bound);
+                                //         }
+                                // }
                         }
                 }
         }
@@ -671,15 +1068,11 @@ void print_device_name(char *path) {
         char name[256];
 
         int fd = open(path, O_RDONLY);
-
-        ioctl(fd, EVIOCGNAME(sizeof(name)), name);
-
-
+        ioctl(fd, EVIOCGNAME(sizeof(name)), name); 
         printf("%s", name);
-
-
         close(fd);
 }
+
 
 void banner() {
         printf("********************************************************************************\n"
@@ -706,9 +1099,6 @@ void banner() {
         printf("********************************************************************************\n");
 
 
-        // for(int i = 0; i < device_count; i++) {
-                // get_device_name(named_inputs[i]);
-        // }
 }
 
 
@@ -812,19 +1202,21 @@ int main(int argc, char **argv) {
         banner();
         main_loop();
 
-        // close everything
-        for (int i = 0; i < device_count; i++) {
-                libevdev_uinput_destroy(uidevs[i]);
-                libevdev_free(output_devs[i]);
-                close(input_fds[i]);
+        // // close everything
+        // for (int i = 0; i < device_count; i++) {
+        //         libevdev_uinput_destroy(uidevs[i]);
+        //         libevdev_free(output_devs[i]);
+        //         close(input_fds[i]);
 
 
 
-                // if in qubes, restart the associated qubes-input-sender service for each of the input devices
-                if(is_qubes) {
-                        change_qubes_input_sender("start", named_inputs[i]);
-                }
-        }
+        //         // if in qubes, restart the associated qubes-input-sender service for each of the input devices
+        //         if(is_qubes) {
+        //                 change_qubes_input_sender("start", named_inputs[i]);
+        //         }
+        // }
+
+        cleanup();
 
         exit(EXIT_SUCCESS);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -180,11 +180,11 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
         if(strncmp(systemd_command, "stop", 4) == 0 || strncmp(systemd_command, "start", 5) == 0) {
                 status = change_qubes_input_sender("status", device_path);
 
-                if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || (status == 3 && strncmp(systemd_command, "start", 5) == 0)) {
+                if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || strncmp(systemd_command, "start", 5) == 0) {
                         snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
 
                         if(verbose) {
-                                printf("keyboard Executing: %s\n", command);
+                                printf("Executing: %s\n", command);
                         }
                         return system(command);
 
@@ -192,7 +192,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                 else {
                         snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager status qubes-input-sender-keyboard-mouse@event%s.service 2> /dev/null > /dev/null", dev_num);
                         if(verbose) {
-                                printf("keyboard/mouse Executing: %s\n", command);
+                                printf("Executing: %s\n", command);
                         }
 
                         status = system(command);
@@ -200,7 +200,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                         if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || (status == 3 && strncmp(systemd_command, "start", 5) == 0)) {
                                 snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard-mouse@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
                                 if(verbose) {
-                                        printf("keyboard/mouse inner Executing: %s\n", command);
+                                        printf("Executing: %s\n", command);
                                 }
                                 
                                 return system(command);
@@ -580,13 +580,10 @@ int main(int argc, char **argv) {
         }
 
 
+        
+
         // see if running in qubes
-        FILE *qubes_file;
-        if(qubes_file = fopen("/var/run/qubes/this-is-appvm", "r")) {
-                fclose(qubes_file);
-                is_qubes = 1;
-        } else if (qubes_file = fopen("/var/run/qubes/this-is-netvm", "r")) {
-                fclose(qubes_file);
+        if(system("stat /var/run/qubes 2> /dev/null > /dev/null") == 0) {
                 is_qubes = 1;
         }
 
@@ -628,19 +625,12 @@ int main(int argc, char **argv) {
         for (int i = 0; i < device_count; i++) {
                 libevdev_uinput_destroy(uidevs[i]);
                 libevdev_free(output_devs[i]);
-
-                // release the device
-                ioctl(input_fds[i], EVIOCGRAB, 0);
-
-
                 close(input_fds[i]);
 
 
 
                 // if in qubes, restart the associated qubes-input-sender service for each of the input devices
                 if(is_qubes) {
-
-                        
                         change_qubes_input_sender("start", named_inputs[i]);
                 }
         }

--- a/src/main.c
+++ b/src/main.c
@@ -226,7 +226,7 @@ int is_mouse(int fd) {
 
 
 // extracts device number from device_path and puts it into dev_num
-void get_device_number(char *dev_num, char *device_path, const int max_len) {
+void get_device_number(char *dev_num, char *device_path) {
 
         // snprintf(dev_num, max_len, device_path + 16);
 //         switch from snprintf to sscanf to avoid warnings from -Wformat-security
@@ -250,7 +250,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
 
         char dev_num[5];
 
-        get_device_number(dev_num, device_path, 5);
+        get_device_number(dev_num, device_path);
 
         int status = 0;
 
@@ -1195,11 +1195,11 @@ int main(int argc, char **argv) {
 
 
                         // remove spaces from line
-                        for(int i = 0 ; i < length; i++) {
+                        for(long unsigned int i = 0 ; i < length; i++) {
 
 
                                 if(isspace(line[i])) {
-                                        for(int j = i; j < length; j++) {
+                                        for(long unsigned int j = i; j < length; j++) {
                                                 line[j] = line[j+1];
                                         }
                                         i--;
@@ -1221,7 +1221,7 @@ int main(int argc, char **argv) {
 
 
                         // find the index of =
-                        for(int i = 0; i < length; i++) {
+                        for(long unsigned int i = 0; i < length; i++) {
                                 if(line[i] == '=') {
                                         equal = i;
                                         break;

--- a/src/main.c
+++ b/src/main.c
@@ -482,7 +482,7 @@ void main_loop() {
                                 }
 
 
-                                if(ev.type == EV_REL && ev.value != 0 && max_noise != 0) {
+                                if(ev.type == EV_REL && ev.value != 0 ) {
                                         if(ev.code == REL_X) {
 
                                                 // select a random midpoint to add the perpendicular move
@@ -580,49 +580,49 @@ void main_loop() {
                                 last_event_time = n1->time;
 
 
-                                // // if mouse move, buffer the extra events
-                                // if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                // if mouse move, buffer the extra events
+                                if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
 
 
-                                //         // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
-                                //         random_delay = random_between(lower_bound, max_delay);
-                                //         n2 = malloc(sizeof(struct entry));
-                                //         n2->time = current_time + (long) random_delay;
-                                //         n2->iev = ev2;
-                                //         n2->device_index = k;
-                                //         TAILQ_INSERT_TAIL(&head, n2, entries);
+                                        // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
+                                        long random_delay = random_between(lower_bound, max_delay);
+                                        n2 = malloc(sizeof(struct entry));
+                                        n2->time = current_time + (long) random_delay;
+                                        n2->iev = ev2;
+                                        n2->device_index = k;
+                                        TAILQ_INSERT_TAIL(&head, n2, entries);
 
-                                //         random_delay = random_between(lower_bound, max_delay);
-                                //         n3 = malloc(sizeof(struct entry));
-                                //         n3->time = current_time + (long) random_delay;
-                                //         n3->iev = ev3;
-                                //         n3->device_index = k;
-                                //         TAILQ_INSERT_TAIL(&head, n3, entries);
+                                        random_delay = random_between(lower_bound, max_delay);
+                                        n3 = malloc(sizeof(struct entry));
+                                        n3->time = current_time + (long) random_delay;
+                                        n3->iev = ev3;
+                                        n3->device_index = k;
+                                        TAILQ_INSERT_TAIL(&head, n3, entries);
 
-                                //         random_delay = random_between(lower_bound, max_delay);
-                                //         n4 = malloc(sizeof(struct entry));
-                                //         n4->time = current_time + (long) random_delay;
-                                //         n4->iev = ev4;
-                                //         n4->device_index = k;
-                                //         TAILQ_INSERT_TAIL(&head, n4, entries);
+                                        random_delay = random_between(lower_bound, max_delay);
+                                        n4 = malloc(sizeof(struct entry));
+                                        n4->time = current_time + (long) random_delay;
+                                        n4->iev = ev4;
+                                        n4->device_index = k;
+                                        TAILQ_INSERT_TAIL(&head, n4, entries);
 
-                                //         random_delay = random_between(lower_bound, max_delay);
-                                //         n5 = malloc(sizeof(struct entry));
-                                //         n5->time = current_time + (long) random_delay;
-                                //         n5->iev = ev5;
-                                //         n5->device_index = k;
-                                //         TAILQ_INSERT_TAIL(&head, n5, entries);
-                                // }
+                                        random_delay = random_between(lower_bound, max_delay);
+                                        n5 = malloc(sizeof(struct entry));
+                                        n5->time = current_time + (long) random_delay;
+                                        n5->iev = ev5;
+                                        n5->device_index = k;
+                                        TAILQ_INSERT_TAIL(&head, n5, entries);
+                                }
 
 
 
                                 // Keep track of the previous scheduled release time
                                 prev_release_time = n1->time;
 
-                                // // on mouse moves
-                                // if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
-                                //         prev_release_time = n5->time;
-                                // }
+                                // on mouse moves
+                                if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                        prev_release_time = n5->time;
+                                }
 
                                 if (verbose) {
                                         printf("Bufferred event at time: %ld. Device: %d,  Type: %*d,  "

--- a/src/main.c
+++ b/src/main.c
@@ -76,6 +76,7 @@ static int rescue_keys[MAX_RESCUE_KEYS];  // Codes of the rescue key combo
 static int rescue_len = 0;  // Number of rescue keys, set during initialization
 
 static int max_delay = DEFAULT_MAX_DELAY_MS;  // lag will never exceed this upper bound
+static int max_delay_mouse = DEFAULT_MAX_MOUSE_DELAY_MS; // lag will never exceed this upper bound on mouse movements
 int max_noise = DEFAULT_MAX_NOISE;
 static int startup_timeout = DEFAULT_STARTUP_DELAY_MS;
 static int max_devices = MAX_DEVICES;
@@ -267,7 +268,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                         snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
 
                         if(verbose) {
-                                printf("Executing: %s\n", command);
+                                printf("Executing: " GREEN("%s\n"), command);
                         }
                         return system(command);
 
@@ -275,7 +276,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                 else {
                         snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager status qubes-input-sender-keyboard-mouse@event%s.service 2> /dev/null > /dev/null", dev_num);
                         if(verbose) {
-                                printf("Executing: %s\n", command);
+                                printf("Executing: " GREEN("%s\n"), command);
                         }
 
                         status = system(command);
@@ -283,7 +284,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                         if((status == 0 && strncmp(systemd_command, "stop", 4) == 0) || (status == 3 && strncmp(systemd_command, "start", 5) == 0)) {
                                 snprintf(command, MAX_COMMAND_LEN, "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard-mouse@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
                                 if(verbose) {
-                                        printf("Executing: %s\n", command);
+                                        printf("Executing: " GREEN("%s\n"), command);
                                 }
                                 
                                 return system(command);
@@ -297,7 +298,7 @@ int change_qubes_input_sender(char *systemd_command, char *device_path) {
                 snprintf(command, MAX_COMMAND_LEN , "sudo systemctl -q --no-pager %s qubes-input-sender-keyboard@event%s.service 2> /dev/null > /dev/null", systemd_command , dev_num);
 
                 if(verbose) {
-                        printf("Executing: %s\n", command);
+                        printf("Executing: " GREEN("%s\n"), command);
                 }
                 
                 return system(command);
@@ -776,8 +777,8 @@ void emit_event(struct entry *e) {
         libevdev_uinput_write_event(uidevs[e->device_index], e->iev.type, e->iev.code, e->iev.value);
 
         if (verbose) {
-                printf("Released event at time : %ld. Device: %d,  Type: %*d,  "
-                       "Code: %*d,  Value: %*d,  Missed target:  %*d ms \n",
+                printf("Released event at time : " GREEN("%ld ") ". Device: " GREEN("%d ") ",  Type: " GREEN("%*d") ",  "
+                       "Code: " GREEN("%*d") ",  Value: " GREEN("%*d") ",  Missed target:  " GREEN("%*d") " ms \n",
                        e->time, e->device_index, 3, e->iev.type, 5, e->iev.code, 5, e->iev.value, 5, delay);
         }
 }
@@ -1105,8 +1106,8 @@ void main_loop() {
                                 }
 
                                 if (verbose) {
-                                        printf("Bufferred event at time: %ld. Device: %d,  Type: %*d,  "
-                                               "Code: %*d,  Value: %*d,  Scheduled delay: %*ld ms \n",
+                                        printf("Bufferred event at time: " GREEN("%ld") ". Device: " GREEN("%d") ", Type: " GREEN("%*d")
+                                               ", Code: " GREEN("%*d") ", Value: " GREEN("%*d") ", Scheduled delay: " GREEN("%*ld") " ms \n",
                                                n1->time, k, 3, n1->iev.type, 5, n1->iev.code, 5, n1->iev.value,
                                                4, random_delay);
                                         if (lower_bound > 0) {
@@ -1189,7 +1190,6 @@ int main(int argc, char **argv) {
 
 
         if(conf_fd != NULL) {
-                printf("Found config file\n");
                 char * line = NULL;
                 char option[50];
                 char value[50];
@@ -1257,6 +1257,7 @@ int main(int argc, char **argv) {
                                 if(val_length < 1) {
                                         continue;
                                 }
+                                
 
                                 if(opt_length == 12 && strncmp(option, "MAX_DELAY_MS", 12) == 0) {
                                         if(!only_digits(value, val_length)) {
@@ -1325,6 +1326,13 @@ int main(int argc, char **argv) {
                                         printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
 
                                         
+                                } else if(opt_length == 18 && strncmp(option, "MAX_MOUSE_DELAY_MS", 18) == 0) {
+                                        if(!only_digits(value, val_length)) {
+                                                printf( YELLOW("Invalid value ")  "%s " YELLOW("for option ") "%s\n", value, option);
+                                                continue;
+                                        }
+                                        sscanf(value, "%d", &max_delay_mouse);
+                                        printf( "Set " GREEN("%s") " to " GREEN("%s\n"), option, value);
                                 } else {
                                         printf( "Unknown option in config file:" YELLOW(" %s\n"), option);
                                 }

--- a/src/main.c
+++ b/src/main.c
@@ -98,6 +98,15 @@ long random_between(long lower, long upper) {
         return lower + randombytes_uniform(upper+1);
 }
 
+static inline long rand_between(long lower, long upper) {
+        if(lower >= upper){
+                return upper;
+        }
+
+        return lower + randombytes_uniform(upper+1);
+}
+
+
 void set_rescue_keys(char* rescue_keys_str) {
         char *_rescue_keys_str = malloc(strlen(rescue_keys_str) + 1);
         strncpy(_rescue_keys_str, rescue_keys_str, strlen(rescue_keys_str));
@@ -480,7 +489,7 @@ void main_loop() {
                                 if (ev.type == EV_SYN) {
                                         random_delay = lower_bound;
                                 } else {
-                                        random_delay = random_between(lower_bound, max_delay);
+                                        random_delay = rand_between(lower_bound, max_delay);
                                 }
 
 
@@ -489,7 +498,8 @@ void main_loop() {
                                         if(ev.code == REL_X) {
 
                                                 // select a random midpoint to add the perpendicular move
-                                                int mid_point = random_between(1, abs(ev.value));
+                                                // int mid_point = random_between(1, abs(ev.value));
+                                                int mid_point = rand_between(1, abs(ev.value));
 
                                                 int final_move = abs(ev.value) - mid_point;
 
@@ -498,10 +508,10 @@ void main_loop() {
                                                         final_move *= -1;
                                                 }
 
-                                                int pixels_y = random_between(1, max_noise);
+                                                int pixels_y = rand_between(1, max_noise);
 
                                                 // randomly decide whether y move will be up or down
-                                                if(random_between(0, 1)) {
+                                                if(rand_between(0, 1)) {
                                                         pixels_y *= -1;
                                                 }
 
@@ -528,7 +538,7 @@ void main_loop() {
 
                                         } else if(ev.code == REL_Y) {
                                                 // select a random midpoint to add the perpendicular move
-                                                int mid_point = random_between(1, abs(ev.value));
+                                                int mid_point = rand_between(1, abs(ev.value));
 
                                                 int final_move = abs(ev.value) - mid_point;
 
@@ -537,10 +547,10 @@ void main_loop() {
                                                         final_move *= -1;
                                                 }
 
-                                                int pixels_x = random_between(1, max_noise);
+                                                int pixels_x = rand_between(1, max_noise);
 
                                                 // randomly decide whether x move will be up or down
-                                                if(random_between(0, 1)) {
+                                                if(rand_between(0, 1)) {
                                                         pixels_x *= -1;
                                                 }
 
@@ -589,7 +599,7 @@ void main_loop() {
 
 
                                         // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
-                                        long random_delay = random_between(lower_bound, max_delay);
+                                        long random_delay = rand_between(lower_bound, max_delay);
                                         n2 = malloc(sizeof(struct entry));
 
                                         // cutting the delay added to each of the mouse cursor moves in half makes them much less painful
@@ -598,21 +608,21 @@ void main_loop() {
                                         n2->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n2, entries);
 
-                                        random_delay = random_between(lower_bound, max_delay);
+                                        random_delay = rand_between(lower_bound, max_delay);
                                         n3 = malloc(sizeof(struct entry));
                                         n3->time = current_time + (long) (random_delay / 3);
                                         n3->iev = ev3;
                                         n3->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n3, entries);
 
-                                        random_delay = random_between(lower_bound, max_delay);
+                                        random_delay = rand_between(lower_bound, max_delay);
                                         n4 = malloc(sizeof(struct entry));
                                         n4->time = current_time + (long) (random_delay / 3);
                                         n4->iev = ev4;
                                         n4->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n4, entries);
 
-                                        random_delay = random_between(lower_bound, max_delay);
+                                        random_delay = rand_between(lower_bound, max_delay);
                                         n5 = malloc(sizeof(struct entry));
                                         n5->time = current_time + (long) (random_delay / 3);
                                         n5->iev = ev5;

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@ static int rescue_keys[MAX_RESCUE_KEYS];  // Codes of the rescue key combo
 static int rescue_len;  // Number of rescue keys, set during initialization
 
 static int max_delay = DEFAULT_MAX_DELAY_MS;  // lag will never exceed this upper bound
-static int max_noise = DEFAULT_MAX_NOISE;
+int max_noise = DEFAULT_MAX_NOISE;
 static int startup_timeout = DEFAULT_STARTUP_DELAY_MS;
 
 static int device_count = 0;
@@ -482,7 +482,7 @@ void main_loop() {
                                 }
 
 
-                                if(ev.type == EV_REL && ev.value != 0 ) {
+                                if(ev.type == EV_REL && ev.value != 0 && max_noise != 0) {
                                         if(ev.code == REL_X) {
 
                                                 // select a random midpoint to add the perpendicular move
@@ -581,34 +581,36 @@ void main_loop() {
 
 
                                 // if mouse move, buffer the extra events
-                                if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
 
 
                                         // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
                                         long random_delay = random_between(lower_bound, max_delay);
                                         n2 = malloc(sizeof(struct entry));
-                                        n2->time = current_time + (long) random_delay;
+
+                                        // cutting the delay added to each of the mouse cursor moves in half makes them much less painful
+                                        n2->time = current_time + (long) (random_delay / 3);
                                         n2->iev = ev2;
                                         n2->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n2, entries);
 
                                         random_delay = random_between(lower_bound, max_delay);
                                         n3 = malloc(sizeof(struct entry));
-                                        n3->time = current_time + (long) random_delay;
+                                        n3->time = current_time + (long) (random_delay / 3);
                                         n3->iev = ev3;
                                         n3->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n3, entries);
 
                                         random_delay = random_between(lower_bound, max_delay);
                                         n4 = malloc(sizeof(struct entry));
-                                        n4->time = current_time + (long) random_delay;
+                                        n4->time = current_time + (long) (random_delay / 3);
                                         n4->iev = ev4;
                                         n4->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n4, entries);
 
                                         random_delay = random_between(lower_bound, max_delay);
                                         n5 = malloc(sizeof(struct entry));
-                                        n5->time = current_time + (long) random_delay;
+                                        n5->time = current_time + (long) (random_delay / 3);
                                         n5->iev = ev5;
                                         n5->device_index = k;
                                         TAILQ_INSERT_TAIL(&head, n5, entries);
@@ -620,7 +622,7 @@ void main_loop() {
                                 prev_release_time = n1->time;
 
                                 // on mouse moves
-                                if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
                                         prev_release_time = n5->time;
                                 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -562,6 +562,9 @@ void init_new_input(char * event_file) {
                         // if not keyboard and mouse, in case qubes-input-sender was stopped, restart it. Don't restart if keyboard or mouse
                         change_qubes_input_sender("start", device);
                         
+                } else {
+                        // not a keyboard or mouse, not qubes
+                        close(fd);
                 }
 
         }

--- a/src/main.c
+++ b/src/main.c
@@ -651,7 +651,7 @@ void usage() {
         fprintf(stderr, "  -k csv_string: csv list of rescue key names to exit kloak in case the\n"
                 "     keyboard becomes unresponsive. Default is 'KEY_LEFTSHIFT,KEY_RIGHTSHIFT,KEY_ESC'.\n");
         fprintf(stderr, "  -v: verbose mode\n");
-        fprintf(stderr, "  -n: max noise added to mouse movements in pixels. Default %d\n", max_noise);
+        fprintf(stderr, "  -n: max noise added to mouse movements in pixels. Default %d\n, can fully disable by setting to 0", max_noise);
 }
 
 void banner() {

--- a/src/main.c
+++ b/src/main.c
@@ -898,8 +898,17 @@ void main_loop() {
                         if(is_qubes) {
                                 restart_all_qubes_input_sender();
                         }
+                        
+                        
+                        // 4 raised on sigterm (ctrl-c), cleanup will be called to close kloak cleanly using sigaction below
+                        if(errno == 4) {
+                                exit(EXIT_SUCCESS);
+                        }
 
+                        
                         panic("poll() failed: %s\n", strerror(errno));
+  
+                        
                 }
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,7 @@
 #define MIN_KEYBOARD_KEYS 20  // need at least this many keys to be a keyboard
 #define POLL_TIMEOUT_MS 1 // timeout to check for new events
 #define DEFAULT_MAX_DELAY_MS 20  // upper bound on event delay
-#define DEFAULT_MAX_NOISE 2
+#define DEFAULT_MAX_NOISE 0
 #define DEFAULT_STARTUP_DELAY_MS 500  // wait before grabbing the input device
 
 #define panic(format, ...) do { fprintf(stderr, format "\n", ## __VA_ARGS__); exit(EXIT_FAILURE); } while (0)

--- a/src/main.c
+++ b/src/main.c
@@ -795,7 +795,7 @@ void init_outputs() {
 
 void emit_event(struct entry *e) {
         
-        int  delay;
+        int  delay, res;
         long now = current_time_ms();
         delay = (int) (e->time - now);
 

--- a/src/main.c
+++ b/src/main.c
@@ -424,8 +424,7 @@ void init_new_input(char * event_file) {
         // if in qubes, need to stop associated qubes-input-sender service before ioctls work on the device file
         if(is_qubes) {
                 // stop the service
-                int service_stop_status = change_qubes_input_sender("stop", device);
-                printf("Status code when stopping the service: %d\n", service_stop_status);
+                change_qubes_input_sender("stop", device);
         }
 
         if ((fd = open(device, O_RDONLY)) >= 0) {

--- a/src/main.c
+++ b/src/main.c
@@ -580,49 +580,49 @@ void main_loop() {
                                 last_event_time = n1->time;
 
 
-                                // if mouse move, buffer the extra events
-                                if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                // // if mouse move, buffer the extra events
+                                // if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
 
 
-                                        // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
-                                        random_delay = random_between(lower_bound, max_delay);
-                                        n2 = malloc(sizeof(struct entry));
-                                        n2->time = current_time + (long) random_delay;
-                                        n2->iev = ev2;
-                                        n2->device_index = k;
-                                        TAILQ_INSERT_TAIL(&head, n2, entries);
+                                //         // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
+                                //         random_delay = random_between(lower_bound, max_delay);
+                                //         n2 = malloc(sizeof(struct entry));
+                                //         n2->time = current_time + (long) random_delay;
+                                //         n2->iev = ev2;
+                                //         n2->device_index = k;
+                                //         TAILQ_INSERT_TAIL(&head, n2, entries);
 
-                                        random_delay = random_between(lower_bound, max_delay);
-                                        n3 = malloc(sizeof(struct entry));
-                                        n3->time = current_time + (long) random_delay;
-                                        n3->iev = ev3;
-                                        n3->device_index = k;
-                                        TAILQ_INSERT_TAIL(&head, n3, entries);
+                                //         random_delay = random_between(lower_bound, max_delay);
+                                //         n3 = malloc(sizeof(struct entry));
+                                //         n3->time = current_time + (long) random_delay;
+                                //         n3->iev = ev3;
+                                //         n3->device_index = k;
+                                //         TAILQ_INSERT_TAIL(&head, n3, entries);
 
-                                        random_delay = random_between(lower_bound, max_delay);
-                                        n4 = malloc(sizeof(struct entry));
-                                        n4->time = current_time + (long) random_delay;
-                                        n4->iev = ev4;
-                                        n4->device_index = k;
-                                        TAILQ_INSERT_TAIL(&head, n4, entries);
+                                //         random_delay = random_between(lower_bound, max_delay);
+                                //         n4 = malloc(sizeof(struct entry));
+                                //         n4->time = current_time + (long) random_delay;
+                                //         n4->iev = ev4;
+                                //         n4->device_index = k;
+                                //         TAILQ_INSERT_TAIL(&head, n4, entries);
 
-                                        random_delay = random_between(lower_bound, max_delay);
-                                        n5 = malloc(sizeof(struct entry));
-                                        n5->time = current_time + (long) random_delay;
-                                        n5->iev = ev5;
-                                        n5->device_index = k;
-                                        TAILQ_INSERT_TAIL(&head, n5, entries);
-                                }
+                                //         random_delay = random_between(lower_bound, max_delay);
+                                //         n5 = malloc(sizeof(struct entry));
+                                //         n5->time = current_time + (long) random_delay;
+                                //         n5->iev = ev5;
+                                //         n5->device_index = k;
+                                //         TAILQ_INSERT_TAIL(&head, n5, entries);
+                                // }
 
 
 
                                 // Keep track of the previous scheduled release time
                                 prev_release_time = n1->time;
 
-                                // on mouse moves
-                                if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
-                                        prev_release_time = n5->time;
-                                }
+                                // // on mouse moves
+                                // if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                //         prev_release_time = n5->time;
+                                // }
 
                                 if (verbose) {
                                         printf("Bufferred event at time: %ld. Device: %d,  Type: %*d,  "

--- a/src/main.c
+++ b/src/main.c
@@ -549,7 +549,7 @@ void main_loop() {
 
                                                 int pixels_x = rand_between(1, max_noise);
 
-                                                // randomly decide whether x move will be up or down
+                                                // randomly decide whether x move will be left or right
                                                 if(rand_between(0, 1)) {
                                                         pixels_x *= -1;
                                                 }
@@ -667,15 +667,34 @@ void usage() {
         fprintf(stderr, "  -n: max noise added to mouse movements in pixels. Default %d\n, can fully disable by setting to 0", max_noise);
 }
 
+void print_device_name(char *path) {
+        char name[256];
+
+        int fd = open(path, O_RDONLY);
+
+        ioctl(fd, EVIOCGNAME(sizeof(name)), name);
+
+
+        printf("%s", name);
+
+
+        close(fd);
+}
+
 void banner() {
         printf("********************************************************************************\n"
                "* Started kloak : Keystroke-level Online Anonymizing Kernel\n"
                "* Maximum delay : %d ms\n"
-               "* Reading from  : %s\n",
+               "* Reading from  : %s (",
                max_delay, named_inputs[0]);
 
+        print_device_name(named_inputs[0]);
+        printf(")\n");
+
         for (int i = 1; i < device_count; i++) {
-                printf("*                 %s\n", named_inputs[i]);
+                printf("*                 %s (", named_inputs[i]);
+                print_device_name(named_inputs[i]);
+                printf(")\n");
         }
 
         printf("* Rescue keys   : %s", lookup_keyname(rescue_keys[0]));
@@ -685,7 +704,14 @@ void banner() {
 
         printf("\n");
         printf("********************************************************************************\n");
+
+
+        // for(int i = 0; i < device_count; i++) {
+                // get_device_name(named_inputs[i]);
+        // }
 }
+
+
 
 int main(int argc, char **argv) {
         if (sodium_init() == -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -188,8 +188,6 @@ int supports_event_type(int device_fd, int event_type) {
 }
 
 int supports_specific_key(int device_fd, unsigned int key) {
-        // size_t nchar = KEY_MAX/8 + 1;
-        // unsigned char bits[nchar];
 
         // change required to avoid warnings from -Wstack-protector
         unsigned char bits[NCHAR];
@@ -230,8 +228,7 @@ int is_mouse(int fd) {
 // extracts device number from device_path and puts it into dev_num
 void get_device_number(char *dev_num, char *device_path) {
 
-        // snprintf(dev_num, max_len, device_path + 16);
-//         switch from snprintf to sscanf to avoid warnings from -Wformat-security
+        // switch from snprintf to sscanf to avoid warnings from -Wformat-security
         sscanf(device_path + 16, "%s", dev_num);
 
 }
@@ -319,7 +316,6 @@ void restart_all_qubes_input_sender() {
 
 void detect_devices() {
         int fd;
-        // char device[256];
 
         // reducing size from 256 to 250 necessary to fix warnings from -Wstringop-truncation. 250 characters is still more than enough since it only stores the path to the device node
         char device[250];
@@ -394,9 +390,6 @@ void cleanup(){
 
 
 void cleanup_device(char * event_file) {
-        // int fd;
-        // int one = 1;
-
 
         char device[256];
         sprintf(device, "/dev/input/%s", event_file);
@@ -404,9 +397,6 @@ void cleanup_device(char * event_file) {
 
         // not an event file
         if(strncmp(event_file, "event", 5) != 0) {
-                // if(verbose) {
-                        // printf("%s is not an event file, skipping clenaup\n", device);
-                // }
                 return;
         }
 
@@ -493,7 +483,6 @@ void init_new_input(char * event_file) {
                 return;
         }
 
-        // char device[256];
 
         // reducing size from 256 to 250 necessary to fix warnings from -Wstringop-truncation. 250 characters is still more than enough since it only stores the path to the device node
         char device[250];
@@ -768,8 +757,6 @@ void init_outputs() {
 }
 
 void emit_event(struct entry *e) {
-//         res is not used
-        // int res, delay;
         
         int  delay;
         long now = current_time_ms();
@@ -811,7 +798,6 @@ void main_loop() {
         // initialize the rescue state
         // using MAX_RESCUE_KEYS necessary to avoid warnings from -Wstack-protector, rescue keys still work exactly the same        
         int rescue_state[MAX_RESCUE_KEYS];
-        // int rescue_state[rescue_len];
         
         for (int i = 0; i < rescue_len; i++) {
                 rescue_state[i] = 0;
@@ -861,7 +847,6 @@ void main_loop() {
                         while(i < len) {
                                 struct inotify_event *ino_event = (struct inotify_event *) &event_buffer[i];
                                 char path[30];
-                                // char dev_name[256];
 
                                 snprintf(path, 30, "/dev/input/%s", ino_event->name);
 
@@ -946,24 +931,20 @@ void main_loop() {
                                 // schedule the keyboard event to be released sometime in the future.
                                 // lower bound must be bounded between time since last scheduled event and max delay
                                 // preserves event order and bounds the maximum delay
-                                // lower_bound = min(max(prev_release_time - current_time, 0), max_delay);
                                 lower_bound = min(max(prev_release_time - current_time, 0), ev.type == EV_REL ? max_delay_mouse : max_delay);
 
                                 // syn events are not delayed
                                 if (ev.type == EV_SYN) {
                                         random_delay = lower_bound;
                                 } else {
-                                        // random_delay = rand_between(lower_bound, max_delay);
                                         random_delay = rand_between(lower_bound, ev.type == EV_REL ? max_delay_mouse : max_delay);
                                 }
 
 
-                                // if(ev.type == EV_REL && ev.value != 0 && max_noise != 0) {
                                 if(mouse_move_with_obfuscation) {
                                         if(ev.code == REL_X) {
 
                                                 // select a random midpoint to add the perpendicular move
-                                                // int mid_point = random_between(1, abs(ev.value));
                                                 int mid_point = rand_between(1, abs(ev.value));
 
                                                 int final_move = abs(ev.value) - mid_point;
@@ -1043,8 +1024,6 @@ void main_loop() {
                                         }
                                 }
 
-                                // int last_event_time = 0;
-
 
 
                                 // Buffer the event
@@ -1055,11 +1034,8 @@ void main_loop() {
                                 TAILQ_INSERT_TAIL(&head, n1, entries);
 
 
-                                // last_event_time = n1->time;
-
 
                                 // if mouse move, buffer the extra events
-                                // if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
                                 if(mouse_move_with_obfuscation) {
 
 
@@ -1067,8 +1043,6 @@ void main_loop() {
                                         long random_delay = rand_between(lower_bound, max_delay_mouse);
                                         n2 = malloc(sizeof(struct entry));
 
-                                        // cutting the delay added to each of the mouse cursor moves in half makes them much less painful
-                                        // n2->time = current_time + (long) (random_delay / 3);
                                         n2->time = current_time + (long) random_delay;
                                         n2->iev = ev2;
                                         n2->device_index = k;
@@ -1076,7 +1050,6 @@ void main_loop() {
 
                                         random_delay = rand_between(lower_bound, max_delay_mouse);
                                         n3 = malloc(sizeof(struct entry));
-                                        // n3->time = current_time + (long) (random_delay / 3);
                                         n3->time = current_time + (long) random_delay;
                                         n3->iev = ev3;
                                         n3->device_index = k;
@@ -1084,7 +1057,6 @@ void main_loop() {
 
                                         random_delay = rand_between(lower_bound, max_delay_mouse);
                                         n4 = malloc(sizeof(struct entry));
-                                        // n4->time = current_time + (long) (random_delay / 3);
                                         n4->time = current_time + (long) random_delay;
                                         n4->iev = ev4;
                                         n4->device_index = k;
@@ -1092,7 +1064,6 @@ void main_loop() {
 
                                         random_delay = rand_between(lower_bound, max_delay_mouse);
                                         n5 = malloc(sizeof(struct entry));
-                                        // n5->time = current_time + (long) (random_delay / 3);
                                         n5->time = current_time + (long) random_delay;
                                         n5->iev = ev5;
                                         n5->device_index = k;
@@ -1105,7 +1076,6 @@ void main_loop() {
                                 prev_release_time = n1->time;
 
                                 // on mouse moves
-                                // if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
                                 if(mouse_move_with_obfuscation) {
                                         prev_release_time = n5->time;
                                 }

--- a/src/main.c
+++ b/src/main.c
@@ -317,7 +317,10 @@ void restart_all_qubes_input_sender() {
 
 void detect_devices() {
         int fd;
-        char device[256];
+        // char device[256];
+
+        // reducing size from 256 to 250 necessary to fix warnings from -Wstringop-truncation. 250 characters is still more than enough since it only stores the path to the device node
+        char device[250];
 
         for (int i = 0; i < max_devices; i++) {
                 sprintf(device, "/dev/input/event%d", i);
@@ -488,12 +491,12 @@ void init_new_input(char * event_file) {
                 return;
         }
 
-        char device[256];
+        // char device[256];
+
+        // reducing size from 256 to 250 necessary to fix warnings from -Wstringop-truncation. 250 characters is still more than enough since it only stores the path to the device node
+        char device[250];
+        
         sprintf(device, "/dev/input/%s", event_file);
-
-
-
-
 
 
 

--- a/src/main.c
+++ b/src/main.c
@@ -482,7 +482,7 @@ void main_loop() {
                                 }
 
 
-                                if(ev.type == EV_REL && ev.value != 0) {
+                                if(ev.type == EV_REL && ev.value != 0 && max_noise != 0) {
                                         if(ev.code == REL_X) {
 
                                                 // select a random midpoint to add the perpendicular move
@@ -542,11 +542,6 @@ void main_loop() {
                                                 }
 
 
-                                                // ev = {.type = EV_REL, .code = REL_Y, .value = mid_point};
-                                                // ev2 = {.type = EV_REL, .code = REL_X, .value = pixels_x};
-                                                // ev3 = {.type = EV_SYN, .code = 0, .value = 0};
-                                                // ev4 = {.type = EV_REL, .code = REL_X, .value = pixels_x * -1};
-                                                // ev5 = {.type = EV_REL, .code = REL_Y, .value = final_move};
 
                                                 ev.type = EV_REL;
                                                 ev.code = REL_Y;
@@ -586,9 +581,10 @@ void main_loop() {
 
 
                                 // if mouse move, buffer the extra events
-                                if(ev.type == EV_REL && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
 
-                                        // int next_time = random_between(last_event_time)
+
+                                        // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
                                         random_delay = random_between(lower_bound, max_delay);
                                         n2 = malloc(sizeof(struct entry));
                                         n2->time = current_time + (long) random_delay;

--- a/src/main.c
+++ b/src/main.c
@@ -201,7 +201,7 @@ int supports_specific_key(int device_fd, unsigned int key) {
 
 int is_keyboard(int fd) {
         int key;
-        int num_supported_keys;
+        int num_supported_keys = 0;
 
         // Only check devices that support EV_KEY events
         if (supports_event_type(fd, EV_KEY)) {
@@ -389,8 +389,8 @@ void cleanup(){
 
 
 void cleanup_device(char * event_file) {
-        int fd;
-        int one = 1;
+        // int fd;
+        // int one = 1;
 
 
         char device[256];
@@ -560,7 +560,7 @@ void init_new_input(char * event_file) {
                         
                         char name[256];
                         
-                        int name_status = ioctl(fd, EVIOCGNAME(sizeof(name)), name);
+                        ioctl(fd, EVIOCGNAME(sizeof(name)), name);
 
 
                         if (verbose) {
@@ -763,7 +763,10 @@ void init_outputs() {
 }
 
 void emit_event(struct entry *e) {
-        int res, delay;
+//         res is not used
+        // int res, delay;
+        
+        int  delay;
         long now = current_time_ms();
         delay = (int) (e->time - now);
 
@@ -855,7 +858,7 @@ void main_loop() {
                         while(i < len) {
                                 struct inotify_event *ino_event = (struct inotify_event *) &event_buffer[i];
                                 char path[30];
-                                char dev_name[256];
+                                // char dev_name[256];
 
                                 snprintf(path, 30, "/dev/input/%s", ino_event->name);
 
@@ -1026,7 +1029,7 @@ void main_loop() {
                                         }
                                 }
 
-                                int last_event_time = 0;
+                                // int last_event_time = 0;
 
 
 
@@ -1038,7 +1041,7 @@ void main_loop() {
                                 TAILQ_INSERT_TAIL(&head, n1, entries);
 
 
-                                last_event_time = n1->time;
+                                // last_event_time = n1->time;
 
 
                                 // if mouse move, buffer the extra events

--- a/src/main.c
+++ b/src/main.c
@@ -10,7 +10,6 @@
 #include <libevdev/libevdev.h>
 #include <libevdev/libevdev-uinput.h>
 #include <ctype.h>
-#include <math.h>
 
 #include "keycodes.h"
 
@@ -33,6 +32,9 @@
 #ifndef max
 #define max(a, b) ( ((a) > (b)) ? (a) : (b) )
 #endif
+
+#define mouse_move_with_obfuscation ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)
+#define abs(x) ((x >= 0) ? x : x * -1)
 
 static int interrupt = 0;  // flag to interrupt the main loop and exit
 static int verbose = 0;  // flag for verbose output
@@ -482,7 +484,8 @@ void main_loop() {
                                 }
 
 
-                                if(ev.type == EV_REL && ev.value != 0 && max_noise != 0) {
+                                // if(ev.type == EV_REL && ev.value != 0 && max_noise != 0) {
+                                if(mouse_move_with_obfuscation) {
                                         if(ev.code == REL_X) {
 
                                                 // select a random midpoint to add the perpendicular move
@@ -536,7 +539,7 @@ void main_loop() {
 
                                                 int pixels_x = random_between(1, max_noise);
 
-                                                // randomly decide whether y move will be up or down
+                                                // randomly decide whether x move will be up or down
                                                 if(random_between(0, 1)) {
                                                         pixels_x *= -1;
                                                 }
@@ -581,7 +584,8 @@ void main_loop() {
 
 
                                 // if mouse move, buffer the extra events
-                                if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                // if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                if(mouse_move_with_obfuscation) {
 
 
                                         // if the times these are given are actually incremental (n2 = n1 + rand, n3 = n2 + rand, etc) it seems to break the cursor movement obfuscation for some reason
@@ -622,7 +626,8 @@ void main_loop() {
                                 prev_release_time = n1->time;
 
                                 // on mouse moves
-                                if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                // if(ev.type == EV_REL && max_noise != 0 && ev.value != 0 && (ev.code == REL_X || ev.code == REL_Y)) {
+                                if(mouse_move_with_obfuscation) {
                                         prev_release_time = n5->time;
                                 }
 


### PR DESCRIPTION
Several changes to allow kloak to work in Qubes in sys-usb if a usb keyboard/mouse is in use or dom0 if a PS/2 keyboard/mouse is in use:
- Detect if Kloak is running in Qubes, if not, kloak will follow the normal execution flow
- Stop the qubes-input-sender services associated with devices so kloak can grab them
- In the event the rescue key sequence is sent, kloak will restart the associated qubes-input-sender services

This will affect typing in all qubes, it's not currently possible to limit it to individual qubes.

Related issue: https://github.com/vmonaco/kloak/issues/47 

Unrelated to Qubes support:
- Added information into README.md on how to install the dependencies necessary to build the version in the dev branch
