### PR TITLE
free pfds after exit to avoid memory leak

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -336,6 +336,8 @@ void main_loop() {
                         }
                 }
         }
+        
+        free(pfds);
 }
 
 void usage() {


### PR DESCRIPTION
There is a small memory leak after the main while loop in main_loop() ends due to pfds not being freed.